### PR TITLE
Use explicit '.json' extension

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -21,10 +21,10 @@ function GitHubColors() {
  */
 GitHubColors.prototype.init = function (ext) {
     if (ext) {
-        return this.extensions = this.extensions || require("./extensions");
+        return this.extensions = this.extensions || require("./extensions.json");
     }
 
-    return this.colors = this.colors || require("./colors");
+    return this.colors = this.colors || require("./colors.json");
 };
 
 /**


### PR DESCRIPTION
Typescript today is unable to resolve JSON files without the '.json' extension like Node can - see https://github.com/microsoft/TypeScript/issues/24357. This adds the explicit extension which works for both Node and Typescript.